### PR TITLE
checked on Windows Server 2022 and Windows Server 2016

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -91,7 +91,11 @@ connectivity エラーが発生している状態でも簡易データベース�
 show-sabanote データベースファイル
 ```
 
-Linux の場合のデータベースファイルは `/var/tmp/mackerel-agent/__sabanote/sabanote.db` です。
+デフォルトのデータベースファイルの位置は以下のとおりです。
+
+- Linux: `/var/tmp/mackerel-agent/__sabanote/sabanote.db`
+- Windows Server 2022: `C:\Windows\SystemTemp\__sabanote\sabanote.db`
+- Windows Server 2016: `C:\Windows\Temp\__sabanote\sabanote.db`
 
 ## ライセンス
 © 2023 Kenshi Muto

--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ The `show-sabanote` command is provided to query information stored in the datab
 show-sabanote <database-file>
 ```
 
-On Linux, the database file is `/var/tmp/mackerel-agent/__sabanote/sabanote.db`.
+Default database location:
+
+- Linux: `/var/tmp/mackerel-agent/__sabanote/sabanote.db`
+- Windows Server 2022: `C:\Windows\SystemTemp\__sabanote\sabanote.db`
+- Windows Server 2016: `C:\Windows\Temp\__sabanote\sabanote.db`
 
 ## License
 © 2023 Kenshi Muto


### PR DESCRIPTION
EC2のWindows Server 2016 と 2022 で確認。
どちらのバージョンでもPowershellのコマンドラインは正常に動作し、切り詰め問題もなさそうだった。
PluginWorkdirの場所は違っている。
